### PR TITLE
Phase 1: Upgrade Spring Boot to 3.5.7 and Java to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #----------------------------------
 
 # Import docker image with maven installed
-FROM maven:3.8.3-openjdk-17 as builder 
+FROM maven:3.9-eclipse-temurin-21 as builder
 
 # Add maintainer, so that new user will understand who had written this Dockerfile
 MAINTAINER Madhup Pandey<madhuppandey2908@gmail.com>
@@ -25,7 +25,7 @@ RUN mvn clean install -DskipTests=true
 #--------------------------------------
 
 # Import small size java image
-FROM openjdk:17-alpine as deployer
+FROM eclipse-temurin:21-jre-alpine as deployer
 
 # Copy build from stage 1 (builder)
 COPY --from=builder /src/target/*.jar /src/target/bankapp.jar

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.3</version>
+		<version>3.5.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -80,8 +80,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-    					<source>1.8</source>
-    					<target>1.8</target>
+    					<source>21</source>
+    					<target>21</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
# Phase 1: Upgrade Spring Boot to 3.5.7 and Java to 21

## Summary
This PR implements Phase 1 of the Spring Boot and Java upgrade plan, updating the banking application from Spring Boot 3.3.3 to 3.5.7 and from Java 17 to Java 21. The changes include:

- Updated Spring Boot parent version from 3.3.3 to 3.5.7 in `pom.xml`
- Updated Java version property from 17 to 21 in `pom.xml`
- Updated maven-compiler-plugin source/target from 1.8 to 21 (fixing previous inconsistency)
- Updated Dockerfile builder stage to use `maven:3.9-eclipse-temurin-21`
- Updated Dockerfile runtime stage to use `eclipse-temurin:21-jre-alpine` (replacing deprecated openjdk images)

**Local Testing Results**: Successfully built Docker image and verified application startup with docker-compose. Application starts correctly, connects to MySQL database, and is accessible at http://localhost:8080.

## Review & Testing Checklist for Human
This is a **significant version upgrade** with moderate risk. Please verify:

- [ ] **Run full test suite** - Tests were skipped during Docker build (`-DskipTests=true`). Run `mvn test` to ensure no test failures with Spring Boot 3.5.7 and Java 21
- [ ] **Verify Spring Boot 3.5.7 compatibility** - Check [Spring Boot 3.5 release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes) for breaking changes that may affect this application
- [ ] **Test end-to-end functionality** - Verify core banking operations (login, account management, transactions) work correctly, not just application startup
- [ ] **Check CI/CD pipeline compatibility** - Ensure Jenkins pipeline and Kubernetes deployments support Java 21 (may need updates to base images or configurations)
- [ ] **Review dependency compatibility** - Verify all dependencies (especially `mysql-connector-java:8.0.33`) are compatible with Java 21 and Spring Boot 3.5.7

### Recommended Test Plan
1. Build and run locally: `mvn clean install && mvn spring-boot:run`
2. Run test suite: `mvn test`
3. Test with docker-compose: `docker-compose up` and verify all endpoints
4. Deploy to staging environment and run smoke tests
5. Monitor application logs for any warnings or deprecation notices

### Notes
- Fixed inconsistency: maven-compiler-plugin was previously set to Java 1.8 while the project used Java 17
- Replaced deprecated `openjdk` images with `eclipse-temurin` as recommended
- MySQL connector version (8.0.33) may need updating for optimal Java 21 support

**Devin Session**: https://app.devin.ai/sessions/2a1d58a8d8a84ae08a8cc4e8102427e1  
**Requested by**: Shawn Azman (@ShawnAzman)